### PR TITLE
[pycsw-load] resume from the most recent date

### DIFF
--- a/bin/pycsw-ckan.py
+++ b/bin/pycsw-ckan.py
@@ -322,7 +322,7 @@ elif COMMAND == 'load':
     with session.begin():
         # This could be None if there is no interrupted load job
         last_processed_metadata_modified = (session.
-            query(ckan_load.c.ckan_modified).order_by(ckan_load.c.ckan_modified).first())
+            query(ckan_load.c.ckan_modified).order_by(ckan_load.c.ckan_modified.desc()).first())
         if last_processed_metadata_modified:
             log.info('Resuming from previous load job metadata_modified=%s', last_processed_metadata_modified)
 


### PR DESCRIPTION
The resume logic is starting with an old date. Explicitly set the sort order so
that we grab the most recent date to resume from.