### PR TITLE
[ckan] index on ckan_collection

### DIFF
--- a/bin/pycsw-ckan.py
+++ b/bin/pycsw-ckan.py
@@ -211,7 +211,7 @@ if COMMAND == 'setup_db':
     ckan_columns = [
         Column('ckan_id', Text, index=True),
         Column('ckan_modified', Text),
-        Column('ckan_collection', Boolean),
+        Column('ckan_collection', Boolean, index=True),
     ]
     try:
         admin.setup_db(DATABASE, TABLE,


### PR DESCRIPTION
Add an index on ckan_collection to speed up queries on pycsw-collection.
> Response time [for csw-collection] for getting a page of 10 items is around 56 s!!

This only adds the index at setup_db time. Pycsw doesn't have migrations, so you can either `CREATE INDEX ON records (ckan_collection);` on an existing database or delete and re-create the table/database.